### PR TITLE
Updated GitHub Action runners to use arm64 natively

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -8,7 +8,7 @@ jobs:
 
   build:
 
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     steps:
       - name:  "add-path"

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -8,8 +8,12 @@ jobs:
   build:
     strategy:
       matrix:
-        platform: [linux/amd64, 'self-hosted arm64']
-    runs-on: ${{ matrix.platform }}
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: macos/arm64
+            runner: self-hosted
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -10,7 +10,6 @@ jobs:
     strategy:
       matrix:
         platform: [linux/amd64, linux/arm64]
-        tag: [amd64, arm64]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -24,6 +23,7 @@ jobs:
               fi
               echo "repo=$(echo ${GITHUB_REPOSITORY} | awk -F / '{print $2}')"  >> $GITHUB_OUTPUT
               echo "tag=$(echo ${GITHUB_REF#refs/heads/} | sed 's/^main$/latest/g')" >> $GITHUB_OUTPUT
+              echo "tag2=$(echo ${{ matrix.platform }} | cut -d/ -f2)" >> $GITHUB_OUTPUT
         id: extract_tag
       - name: Login to Docker Hub
         uses: docker/login-action@v2
@@ -39,7 +39,7 @@ jobs:
           file: ./Dockerfile
           platforms: ${{ matrix.platform }}
           push: true
-          tags: ${{ steps.extract_tag.outputs.uname }}/${{ steps.extract_tag.outputs.repo }}:${{ steps.extract_tag.outputs.tag }}-${{ matrix.tag }}
+          tags: ${{ steps.extract_tag.outputs.uname }}/${{ steps.extract_tag.outputs.repo }}:${{ steps.extract_tag.outputs.tag }}-${{ steps.extract_tag.outputs.tag2 }}
 
   push-manifest:
     needs: build

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -11,8 +11,8 @@ jobs:
         include:
           - platform: linux/amd64
             runner: ubuntu-latest
-          - platform: macos/arm64
-            runner: self-hosted
+          - platform: linux/arm64
+            runner: [self-hosted,arm64]
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout
@@ -30,7 +30,6 @@ jobs:
           TAG=$(echo ${GITHUB_REF#refs/heads/} | sed 's/^main$/latest/g')
           TAG2=$(echo ${{ matrix.platform }} | cut -d/ -f2)
           echo "::set-output name=image::${UNAME}/${REPO}:${TAG}"
-          echo "::set-output name=tag2::${TAG2}"
           echo "::set-output name=image-tag2::${UNAME}/${REPO}:${TAG}-${TAG2}"
 
       - name: Login to Docker Hub
@@ -47,7 +46,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/${{ steps.set-vars.outputs.tag2 }}
+          platforms: ${{ matrix.platform }}
           push: true
           tags: ${{ steps.set-vars.outputs.image-tag2 }}
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -30,6 +30,7 @@ jobs:
           TAG=$(echo ${GITHUB_REF#refs/heads/} | sed 's/^main$/latest/g')
           TAG2=$(echo ${{ matrix.platform }} | cut -d/ -f2)
           echo "::set-output name=image::${UNAME}/${REPO}:${TAG}"
+          echo "::set-output name=tag2::${TAG2}"
           echo "::set-output name=image-tag2::${UNAME}/${REPO}:${TAG}-${TAG2}"
 
       - name: Login to Docker Hub
@@ -46,7 +47,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: ${{ matrix.platform }}
+          platforms: linux/${{ steps.set-vars.outputs.tag2 }}
           push: true
           tags: ${{ steps.set-vars.outputs.image-tag2 }}
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -6,32 +6,37 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
-        platform: [linux/amd64, linux/arm64]
+        platform: [linux/amd64, 'self-hosted arm64']
+    runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Obtain repository and tag names
-        shell: bash
+
+      - name: Set Environment Variables
+        id: set-vars
         run: |
-              if [ -z "${{ secrets.DOCKER_HUB_REPO }}" ]; then
-                  echo "uname=${{ secrets.DOCKER_HUB_USERNAME }}" >> $GITHUB_OUTPUT
-              else
-                  echo "uname=${{ secrets.DOCKER_HUB_REPO }}" >> $GITHUB_OUTPUT
-              fi
-              echo "repo=$(echo ${GITHUB_REPOSITORY} | awk -F / '{print $2}')"  >> $GITHUB_OUTPUT
-              echo "tag=$(echo ${GITHUB_REF#refs/heads/} | sed 's/^main$/latest/g')" >> $GITHUB_OUTPUT
-              echo "tag2=$(echo ${{ matrix.platform }} | cut -d/ -f2)" >> $GITHUB_OUTPUT
-        id: extract_tag
+          if [ -z "${{ secrets.DOCKER_HUB_REPO }}" ]; then
+              UNAME=${{ secrets.DOCKER_HUB_USERNAME }}
+          else
+              UNAME=${{ secrets.DOCKER_HUB_REPO }}
+          fi
+          REPO=$(echo ${GITHUB_REPOSITORY} | awk -F / '{print $2}')
+          TAG=$(echo ${GITHUB_REF#refs/heads/} | sed 's/^main$/latest/g')
+          TAG2=${{ matrix.platform }}${{ matrix.platform }}: -5}
+          echo "::set-output name=image::${UNAME}/${REPO}:${TAG}"
+          echo "::set-output name=image-tag2::${UNAME}/${REPO}:${TAG}-${TAG2}"
+
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
       - name: Build and push
         uses: docker/build-push-action@v3
         with:
@@ -39,36 +44,38 @@ jobs:
           file: ./Dockerfile
           platforms: ${{ matrix.platform }}
           push: true
-          tags: ${{ steps.extract_tag.outputs.uname }}/${{ steps.extract_tag.outputs.repo }}:${{ steps.extract_tag.outputs.tag }}-${{ steps.extract_tag.outputs.tag2 }}
+          tags: ${{ steps.set-vars.outputs.image-tag2 }}
 
   push-manifest:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - name: Obtain repository and tag names
-        shell: bash
+      - name: Set Environment Variables
+        id: set-vars
         run: |
-              if [ -z "${{ secrets.DOCKER_HUB_REPO }}" ]; then
-                  echo "uname=${{ secrets.DOCKER_HUB_USERNAME }}" >> $GITHUB_OUTPUT
-              else
-                  echo "uname=${{ secrets.DOCKER_HUB_REPO }}" >> $GITHUB_OUTPUT
-              fi
-              echo "repo=$(echo ${GITHUB_REPOSITORY} | awk -F / '{print $2}')"  >> $GITHUB_OUTPUT
-              echo "tag=$(echo ${GITHUB_REF#refs/heads/} | sed 's/^main$/latest/g')" >> $GITHUB_OUTPUT
-        id: extract_tag
+          if [ -z "${{ secrets.DOCKER_HUB_REPO }}" ]; then
+              UNAME=${{ secrets.DOCKER_HUB_USERNAME }}
+          else
+              UNAME=${{ secrets.DOCKER_HUB_REPO }}
+          fi
+          REPO=$(echo ${GITHUB_REPOSITORY} | awk -F / '{print $2}')
+          TAG=$(echo ${GITHUB_REF#refs/heads/} | sed 's/^main$/latest/g')
+          echo "::set-output name=image::${UNAME}/${REPO}:${TAG}"
+
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
       - name: Pull Docker images
         run: |
-          docker pull ${{ steps.extract_tag.outputs.uname }}/${{ steps.extract_tag.outputs.repo }}:${{ steps.extract_tag.outputs.tag }}-amd64
-          docker pull ${{ steps.extract_tag.outputs.uname }}/${{ steps.extract_tag.outputs.repo }}:${{ steps.extract_tag.outputs.tag }}-arm64
+          docker pull ${{ steps.set-vars.outputs.image }}-amd64
+          docker pull ${{ steps.set-vars.outputs.image }}-arm64
 
       - name: Create and push Docker manifest
         run: |
-          docker manifest create ${{ steps.extract_tag.outputs.uname }}/${{ steps.extract_tag.outputs.repo }}:${{ steps.extract_tag.outputs.tag }} \
-            --amend ${{ steps.extract_tag.outputs.uname }}/${{ steps.extract_tag.outputs.repo }}:${{ steps.extract_tag.outputs.tag }}-amd64 \
-            --amend ${{ steps.extract_tag.outputs.uname }}/${{ steps.extract_tag.outputs.repo }}:${{ steps.extract_tag.outputs.tag }}-arm64
-          docker manifest push ${{ steps.extract_tag.outputs.uname }}/${{ steps.extract_tag.outputs.repo }}:${{ steps.extract_tag.outputs.tag }}
+          docker manifest create ${{ steps.set-vars.outputs.image }} \
+            --amend ${{ steps.set-vars.outputs.image }}-amd64 \
+            --amend ${{ steps.set-vars.outputs.image }}-arm64
+          docker manifest push ${{ steps.set-vars.outputs.image }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -28,7 +28,7 @@ jobs:
           fi
           REPO=$(echo ${GITHUB_REPOSITORY} | awk -F / '{print $2}')
           TAG=$(echo ${GITHUB_REF#refs/heads/} | sed 's/^main$/latest/g')
-          TAG2=${{ matrix.platform }}${{ matrix.platform }}: -5}
+          TAG2=$(echo ${{ matrix.platform }} | cut -d/ -f2)
           echo "::set-output name=image::${UNAME}/${REPO}:${TAG}"
           echo "::set-output name=image-tag2::${UNAME}/${REPO}:${TAG}-${TAG2}"
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -8,7 +8,7 @@ jobs:
 
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - name:  "add-path"

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,49 +1,74 @@
-name: Docker Image CI
+name: Build and push multi-platform Docker images
 
 on:
   push:
     branches: '*'
 
 jobs:
-
   build:
-
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        platform: [linux/amd64, linux/arm64]
+        tag: [amd64, arm64]
     steps:
-      - name:  "add-path"
-        shell: pwsh
-        run: Add-Content $env:GITHUB_PATH "C:\Program Files\Git\bin"
-        if: runner.os == 'Windows'
       - name: Checkout
         uses: actions/checkout@v3
       - name: Obtain repository and tag names
         shell: bash
         run: |
-             if [ -z "${{ secrets.DOCKER_HUB_REPO }}" ]; then
-                 echo "uname=${{ secrets.DOCKER_HUB_USERNAME }}" >> $GITHUB_OUTPUT
-             else
-                 echo "uname=${{ secrets.DOCKER_HUB_REPO }}" >> $GITHUB_OUTPUT
-             fi
-             echo "repo=$(echo ${GITHUB_REPOSITORY} | awk -F / '{print $2}')"  >> $GITHUB_OUTPUT
-             echo "tag=$(echo ${GITHUB_REF#refs/heads/} | sed 's/^main$/latest/g')" >> $GITHUB_OUTPUT
+              if [ -z "${{ secrets.DOCKER_HUB_REPO }}" ]; then
+                  echo "uname=${{ secrets.DOCKER_HUB_USERNAME }}" >> $GITHUB_OUTPUT
+              else
+                  echo "uname=${{ secrets.DOCKER_HUB_REPO }}" >> $GITHUB_OUTPUT
+              fi
+              echo "repo=$(echo ${GITHUB_REPOSITORY} | awk -F / '{print $2}')"  >> $GITHUB_OUTPUT
+              echo "tag=$(echo ${GITHUB_REF#refs/heads/} | sed 's/^main$/latest/g')" >> $GITHUB_OUTPUT
         id: extract_tag
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Build and push
         uses: docker/build-push-action@v3
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platform }}
           push: true
-          tags: ${{ steps.extract_tag.outputs.uname }}/${{ steps.extract_tag.outputs.repo }}:${{ steps.extract_tag.outputs.tag }}
+          tags: ${{ steps.extract_tag.outputs.uname }}/${{ steps.extract_tag.outputs.repo }}:${{ steps.extract_tag.outputs.tag }}-${{ matrix.tag }}
 
-# Reference: https://docs.docker.com/ci-cd/github-actions/
+  push-manifest:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Obtain repository and tag names
+        shell: bash
+        run: |
+              if [ -z "${{ secrets.DOCKER_HUB_REPO }}" ]; then
+                  echo "uname=${{ secrets.DOCKER_HUB_USERNAME }}" >> $GITHUB_OUTPUT
+              else
+                  echo "uname=${{ secrets.DOCKER_HUB_REPO }}" >> $GITHUB_OUTPUT
+              fi
+              echo "repo=$(echo ${GITHUB_REPOSITORY} | awk -F / '{print $2}')"  >> $GITHUB_OUTPUT
+              echo "tag=$(echo ${GITHUB_REF#refs/heads/} | sed 's/^main$/latest/g')" >> $GITHUB_OUTPUT
+        id: extract_tag
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      - name: Pull Docker images
+        run: |
+          docker pull ${{ steps.extract_tag.outputs.uname }}/${{ steps.extract_tag.outputs.repo }}:${{ steps.extract_tag.outputs.tag }}-amd64
+          docker pull ${{ steps.extract_tag.outputs.uname }}/${{ steps.extract_tag.outputs.repo }}:${{ steps.extract_tag.outputs.tag }}-arm64
+
+      - name: Create and push Docker manifest
+        run: |
+          docker manifest create ${{ steps.extract_tag.outputs.uname }}/${{ steps.extract_tag.outputs.repo }}:${{ steps.extract_tag.outputs.tag }} \
+            --amend ${{ steps.extract_tag.outputs.uname }}/${{ steps.extract_tag.outputs.repo }}:${{ steps.extract_tag.outputs.tag }}-amd64 \
+            --amend ${{ steps.extract_tag.outputs.uname }}/${{ steps.extract_tag.outputs.repo }}:${{ steps.extract_tag.outputs.tag }}-arm64
+          docker manifest push ${{ steps.extract_tag.outputs.uname }}/${{ steps.extract_tag.outputs.repo }}:${{ steps.extract_tag.outputs.tag }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -90,7 +90,9 @@ RUN mkdir -p $DOCKER_HOME/.vscode && \
         --install-extension davidanson.vscode-markdownlint \
         --install-extension fortran-lang.linter-gfortran \
         --install-extension ms-python.python && \
+    echo "Finished installing vscode extensions" && \
     chmod -R a+r $HOME/.config && \
+    echo "Finished changing modes" && \
     find $DOCKER_HOME -type d -exec chmod a+x {} \;
 
 USER root

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,10 +75,26 @@ RUN mkdir -p $DOCKER_HOME/.vscode && \
     mv $DOCKER_HOME/.vscode $DOCKER_HOME/.config/vscode && \
     ln -s -f $DOCKER_HOME/.config/vscode $DOCKER_HOME/.vscode && \
     code --install-extension github.copilot \
-        --install-extension github.copilot-chat && \
-    echo "Finished installing vscode extensions" && \
+        --install-extension github.copilot-chat \
+        --install-extension github.vscode-pull-request-github \
+        --install-extension genieai.chatgpt-vscode \
+        --install-extension ms-vscode.cpptools \
+        --install-extension ms-vscode.cpptools-extension-pack \
+        --install-extension ms-vscode.makefile-tools \
+        --install-extension mathworks.language-matlab \
+        --install-extension cschlosser.doxdocgen \
+        --install-extension bbenoist.doxygen \
+        --install-extension streetsidesoftware.code-spell-checker \
+        --install-extension eamodio.gitlens \
+        --install-extension yzhang.markdown-all-in-one \
+        --install-extension davidanson.vscode-markdownlint \
+        --install-extension fortran-lang.linter-gfortran \
+        --install-extension ms-python.python \
+        --install-extension twxs.cmake \
+        --install-extension shardulm94.trailing-spaces \
+        --install-extension foxundermoon.shell-format \
+        --install-extension timonwong.shellcheck && \
     chmod -R a+r $HOME/.config && \
-    echo "Finished changing modes" && \
     find $DOCKER_HOME -type d -exec chmod a+x {} \;
 
 USER root

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,9 +75,7 @@ RUN mkdir -p $DOCKER_HOME/.vscode && \
     mv $DOCKER_HOME/.vscode $DOCKER_HOME/.config/vscode && \
     ln -s -f $DOCKER_HOME/.config/vscode $DOCKER_HOME/.vscode && \
     code --install-extension github.copilot \
-        --install-extension github.copilot-chat \
-        --install-extension github.vscode-pull-request-github \
-        --install-extension genieai.chatgpt-vscode && \
+        --install-extension github.copilot-chat && \
     echo "Finished installing vscode extensions" && \
     chmod -R a+r $HOME/.config && \
     echo "Finished changing modes" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -87,8 +87,6 @@ RUN mkdir -p $DOCKER_HOME/.vscode && \
         --install-extension streetsidesoftware.code-spell-checker \
         --install-extension eamodio.gitlens \
         --install-extension yzhang.markdown-all-in-one \
-        --install-extension davidanson.vscode-markdownlint \
-        --install-extension fortran-lang.linter-gfortran \
         --install-extension ms-python.python && \
     echo "Finished installing vscode extensions" && \
     chmod -R a+r $HOME/.config && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -89,11 +89,7 @@ RUN mkdir -p $DOCKER_HOME/.vscode && \
         --install-extension yzhang.markdown-all-in-one \
         --install-extension davidanson.vscode-markdownlint \
         --install-extension fortran-lang.linter-gfortran \
-        --install-extension ms-python.python \
-        --install-extension twxs.cmake \
-        --install-extension shardulm94.trailing-spaces \
-        --install-extension foxundermoon.shell-format \
-        --install-extension timonwong.shellcheck && \
+        --install-extension ms-python.python && \
     chmod -R a+r $HOME/.config && \
     find $DOCKER_HOME -type d -exec chmod a+x {} \;
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,14 +77,7 @@ RUN mkdir -p $DOCKER_HOME/.vscode && \
     code --install-extension github.copilot \
         --install-extension github.copilot-chat \
         --install-extension github.vscode-pull-request-github \
-        --install-extension genieai.chatgpt-vscode \
-        --install-extension ms-vscode.cpptools \
-        --install-extension ms-vscode.cpptools-extension-pack \
-        --install-extension ms-vscode.makefile-tools \
-        --install-extension mathworks.language-matlab \
-        --install-extension cschlosser.doxdocgen \
-        --install-extension bbenoist.doxygen \
-        --install-extension streetsidesoftware.code-spell-checker && \
+        --install-extension genieai.chatgpt-vscode && \
     echo "Finished installing vscode extensions" && \
     chmod -R a+r $HOME/.config && \
     echo "Finished changing modes" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,10 +84,7 @@ RUN mkdir -p $DOCKER_HOME/.vscode && \
         --install-extension mathworks.language-matlab \
         --install-extension cschlosser.doxdocgen \
         --install-extension bbenoist.doxygen \
-        --install-extension streetsidesoftware.code-spell-checker \
-        --install-extension eamodio.gitlens \
-        --install-extension yzhang.markdown-all-in-one \
-        --install-extension ms-python.python && \
+        --install-extension streetsidesoftware.code-spell-checker && \
     echo "Finished installing vscode extensions" && \
     chmod -R a+r $HOME/.config && \
     echo "Finished changing modes" && \


### PR DESCRIPTION
When installing extensions for VS Code, using QEMU for cross-platform emulation fails. Build the images natively on amd64 and arm64 and then use `docker manifest` to merge them.